### PR TITLE
Allow configuring model storage directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Both Grounding DINO and SAM weights are downloaded automatically from the Hugging Face Hub on first use. Make sure you have enough disk space (~2.5 GB) and that you are logged in with `huggingface-cli login` if the models require authentication.
+Both Grounding DINO and SAM weights are downloaded automatically from the Hugging Face Hub on first use. Make sure you have enough disk space (~2.5 GB) and that you are logged in with `huggingface-cli login` if the models require authentication. Use the `--models-dir` flag (or the `models_dir` argument in the Python API) to override the default cache location and store all model files in a custom directory.
 
 ## Usage
 
@@ -37,6 +37,9 @@ You can tweak the detection thresholds if you want to be more or less conservati
 
 ```bash
 python -m dendrotector path/to/image.jpg --box-threshold 0.25 --text-threshold 0.2
+
+# Store all downloaded models inside ./weights instead of the default cache
+python -m dendrotector path/to/image.jpg --models-dir weights
 ```
 
 To run the detector on a specific device (e.g. CUDA) explicitly, pass `--device cuda`. On machines equipped with NVIDIA GPUs such as the H100, CUDA will be selected automatically when available.
@@ -46,7 +49,7 @@ To run the detector on a specific device (e.g. CUDA) explicitly, pass `--device 
 ```python
 from dendrotector import DendroDetector
 
-detector = DendroDetector()
+detector = DendroDetector(models_dir="weights")
 results = detector.detect("forest.jpg", "outputs/forest")
 
 for result in results:

--- a/dendrotector/cli.py
+++ b/dendrotector/cli.py
@@ -29,6 +29,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         help="Computation device to run on (defaults to CUDA if available)",
     )
+    parser.add_argument(
+        "--models-dir",
+        type=Path,
+        default=None,
+        help="Directory where model weights should be stored",
+    )
     return parser
 
 
@@ -40,6 +46,7 @@ def main(argv: list[str] | None = None) -> None:
         device=args.device,
         box_threshold=args.box_threshold,
         text_threshold=args.text_threshold,
+        models_dir=args.models_dir,
     )
     results = detector.detect(args.image, args.output_dir, multimask_output=args.multimask)
 


### PR DESCRIPTION
## Summary
- add a `models_dir` option to `DendroDetector` so all downloads can be stored in a user-provided directory
- expose the new option on the CLI via `--models-dir` and document the flag in the README

## Testing
- python -m compileall dendrotector

------
https://chatgpt.com/codex/tasks/task_e_68d59003f56c832fac571a03fadb5411