### PR TITLE
Fix GroundingDINO installation instructions and add example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,33 @@ pip install -r requirements.txt
 
 Both Grounding DINO and SAM weights are downloaded automatically from the Hugging Face Hub on first use. Make sure you have enough disk space (~2.5 GB) and that you are logged in with `huggingface-cli login` if the models require authentication. Use the `--models-dir` flag (or the `models_dir` argument in the Python API) to override the default cache location and store all model files in a custom directory.
 
+### Troubleshooting installation
+
+The wheel published on PyPI for Grounding DINO (`groundingdino-py`) is currently missing
+several CUDA source files. As a result, `pip install groundingdino-py` fails with an
+error similar to:
+
+```
+cc1plus: fatal error: .../groundingdino/models/GroundingDINO/csrc/vision.cpp: No such file or directory
+```
+
+To avoid this issue the project depends directly on the official GitHub repository,
+which provides the missing sources:
+
+```bash
+pip install git+https://github.com/IDEA-Research/GroundingDINO.git@v0.1.0-alpha2
+```
+
+Building the CUDA/C++ extension also requires a compiler toolchain and Ninja. On
+Debian/Ubuntu you can install the prerequisites with:
+
+```bash
+sudo apt-get install build-essential ninja-build
+```
+
+If you install dependencies inside a managed environment (e.g. Google Colab), make
+sure to run the command above before invoking `pip install -r requirements.txt`.
+
 ## Usage
 
 ```bash

--- a/example.py
+++ b/example.py
@@ -1,0 +1,84 @@
+"""Minimal script showcasing how to run the Dendrotector pipeline."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from dendrotector import DendroDetector
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("image", type=Path, help="Path to the image to analyse.")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("outputs"),
+        help="Where to store the generated masks and metadata.",
+    )
+    parser.add_argument(
+        "--models-dir",
+        type=Path,
+        default=None,
+        help="Optional directory where model weights should be cached.",
+    )
+    parser.add_argument(
+        "--device",
+        default=None,
+        help="Computation device (e.g. 'cuda', 'cuda:0' or 'cpu').",
+    )
+    parser.add_argument(
+        "--box-threshold",
+        type=float,
+        default=0.3,
+        help="Box confidence threshold for Grounding DINO.",
+    )
+    parser.add_argument(
+        "--text-threshold",
+        type=float,
+        default=0.25,
+        help="Text confidence threshold for Grounding DINO.",
+    )
+    parser.add_argument(
+        "--prompt",
+        default="tree . shrub . bush .",
+        help="Text prompt used to query Grounding DINO.",
+    )
+    parser.add_argument(
+        "--multimask-output",
+        action="store_true",
+        help="Ask SAM for multiple mask hypotheses per detection.",
+    )
+    return parser
+
+
+def main() -> None:
+    args = build_parser().parse_args()
+    detector = DendroDetector(
+        device=args.device,
+        box_threshold=args.box_threshold,
+        text_threshold=args.text_threshold,
+        models_dir=args.models_dir,
+    )
+
+    results = detector.detect(
+        image_path=args.image,
+        output_dir=args.output_dir,
+        prompt=args.prompt,
+        multimask_output=args.multimask_output,
+    )
+
+    if not results:
+        print("No trees or shrubs detected.")
+        return
+
+    print(f"Saved outputs to {args.output_dir.resolve()}")
+    for result in results:
+        print(
+            f"label={result.label!r} score={result.score:.3f} "
+            f"bbox={result.bbox} mask={result.mask_path}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch>=2.1.0
 torchvision>=0.16.0
-groundingdino>=0.1.0
+groundingdino @ git+https://github.com/IDEA-Research/GroundingDINO.git@v0.1.0-alpha2
 git+https://github.com/facebookresearch/segment-anything.git
 huggingface-hub>=0.20.0
 opencv-python>=4.7.0


### PR DESCRIPTION
## Summary
- switch the Grounding DINO dependency to install directly from the official GitHub repository tag that is actually published (`v0.1.0-alpha2`)
- document the corrected tag in the README alongside the installation guidance

## Testing
- python -m compileall dendrotector example.py

------
https://chatgpt.com/codex/tasks/task_e_68d5921f470c832f822772790b4006b0