### PR TITLE
Integrate pretrained tree species classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Dendrotector is an instance segmentation pipeline tailored for spotting trees an
 - Export of bounding boxes, masks (with transparency), and a JSON summary for downstream processing.
 - Overlay rendering with bounding boxes and colored masks for quick visual inspection.
 - Optional downstream module that crops each detection and performs species-level
-  classification with high-capacity Hugging Face vision models.
+  classification with a pretrained Swin Transformer fine-tuned on tree and shrub
+  species (``OttoYu/TreeClassification``).
 
 ## Installation
 
@@ -54,6 +55,9 @@ sure to run the command above before invoking `pip install -r requirements.txt`.
 
 ```bash
 python -m dendrotector path/to/image.jpg --output-dir results/
+
+# Run detection and species classification in one go
+python -m dendrotector path/to/image.jpg --output-dir results/ --classify-species
 ```
 
 The command creates the following artifacts inside the chosen output directory:
@@ -76,18 +80,12 @@ To run the detector on a specific device (e.g. CUDA) explicitly, pass `--device 
 ## Programmatic API
 
 ```python
-from dendrotector import (
-    DendroDetector,
-    SpeciesIdentifier,
-)
+from dendrotector import DendroDetector, SpeciesIdentifier
 
 detector = DendroDetector(models_dir="weights")
 detections = detector.detect("forest.jpg", "outputs/forest")
 
-identifier = SpeciesIdentifier(
-    model_name_or_path="google/vit-huge-patch14-224-in21k",
-    batch_size=2,
-)
+identifier = SpeciesIdentifier(batch_size=2)
 species_predictions = identifier.identify("forest.jpg", detections, "outputs/forest")
 
 for prediction in species_predictions:

--- a/example.py
+++ b/example.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
-from dendrotector import DendroDetector
+from dendrotector import DendroDetector, SpeciesIdentifier
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -49,6 +49,44 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Ask SAM 2 for multiple mask hypotheses per detection.",
     )
+    parser.add_argument(
+        "--skip-species",
+        action="store_true",
+        help="Skip the species classification stage.",
+    )
+    parser.add_argument(
+        "--species-model",
+        default=SpeciesIdentifier.DEFAULT_MODEL_ID,
+        help="Hugging Face model to use for species classification.",
+    )
+    parser.add_argument(
+        "--species-device",
+        default=None,
+        help="Device for the species classifier (defaults to the detector device).",
+    )
+    parser.add_argument(
+        "--species-top-k",
+        type=int,
+        default=5,
+        help="Number of top species predictions to store per detection.",
+    )
+    parser.add_argument(
+        "--species-crop-padding",
+        type=float,
+        default=0.05,
+        help="Extra padding added around each detection before cropping for classification.",
+    )
+    parser.add_argument(
+        "--species-batch-size",
+        type=int,
+        default=4,
+        help="Maximum number of cropped instances to classify at once.",
+    )
+    parser.add_argument(
+        "--species-keep-background",
+        action="store_true",
+        help="Disable mask application and keep the original background in the crops.",
+    )
     return parser
 
 
@@ -72,11 +110,44 @@ def main() -> None:
         print("No trees or shrubs detected.")
         return
 
-    print(f"Saved outputs to {args.output_dir.resolve()}")
+    print(f"Saved detection outputs to {args.output_dir.resolve()}")
     for result in results:
         print(
             f"label={result.label!r} score={result.score:.3f} "
             f"bbox={result.bbox} mask={result.mask_path}"
+        )
+
+    if args.skip_species:
+        return
+
+    taxonomy_dir = args.output_dir / "species"
+    identifier = SpeciesIdentifier(
+        model_name_or_path=args.species_model,
+        device=args.species_device or args.device,
+        top_k=args.species_top_k,
+        crop_padding=args.species_crop_padding,
+        apply_mask=not args.species_keep_background,
+        batch_size=args.species_batch_size,
+        models_dir=args.models_dir,
+    )
+    predictions = identifier.identify(
+        image_path=args.image,
+        detections=results,
+        output_dir=taxonomy_dir,
+    )
+
+    if not predictions:
+        print("Species identifier did not return any predictions.")
+        return
+
+    print(f"Saved species outputs to {taxonomy_dir.resolve()}")
+    for prediction in predictions:
+        top_k_summary = ", ".join(
+            f"{label} ({score:.3f})" for label, score in prediction.top_k
+        )
+        print(
+            f"crop={prediction.crop_path} label={prediction.label!r} "
+            f"score={prediction.score:.3f} top_k=[{top_k_summary}]"
         )
 
 

--- a/example_with_specifying.py
+++ b/example_with_specifying.py
@@ -65,7 +65,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--species-model",
-        default="google/vit-huge-patch14-224-in21k",
+        default=SpeciesIdentifier.DEFAULT_MODEL_ID,
         help="Hugging Face model identifier for species classification.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- replace the placeholder species identifier with the OttoYu/TreeClassification Swin Transformer, adding GPU-friendly defaults, crop masking, and model metadata export
- expose species classification from the CLI and example script so detections can be cropped and classified end-to-end with adjustable batching and padding options
- refresh documentation and advanced examples to highlight the tree-specific classifier and new usage patterns

## Testing
- python -m compileall dendrotector example.py example_dir.py example_with_specifying.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f4a1bf20832f9d0fc14c13ae9124