### PR TITLE
Fix circular import between detector and report

### DIFF
--- a/dendrotector/report.py
+++ b/dendrotector/report.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Sequence
+from typing import TYPE_CHECKING, Any, Sequence
 
-from .detector import DetectionResult
+if TYPE_CHECKING:  # pragma: no cover - imported for static analysis only
+    from .detector import DetectionResult
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- guard the type-only dependency on `DetectionResult` in `report.py`
- avoid importing `detector` at module import time to remove the circular dependency

## Testing
- not run (system dependency `libGL.so.1` required for OpenCV import)


------
https://chatgpt.com/codex/tasks/task_e_68d95819b0e4832f89184beaa41df626