### PR TITLE
Add Docker deployment workflow for API service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Dockerfile for serving the DendroDetector API via FastAPI/uvicorn.
+FROM pytorch/pytorch:2.2.1-cuda12.1-cudnn8-runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Default configuration values that can be overridden at runtime.
+ENV PORT=8000 \
+    DENDROTECTOR_DEVICE=
+
+EXPOSE 8000
+
+CMD ["/bin/bash", "-lc", "uvicorn dendrotector.api:app --host 0.0.0.0 --port ${PORT}"]

--- a/dendrotector/api.py
+++ b/dendrotector/api.py
@@ -9,6 +9,10 @@ Typical usage when deploying on a remote machine::
 
     uvicorn dendrotector.api:app --host 0.0.0.0 --port 8000
 
+The detector device can be overridden by setting the ``DENDROTECTOR_DEVICE``
+environment variable before starting the server (for example ``cpu`` or
+``cuda:0``).
+
 """
 from __future__ import annotations
 
@@ -41,6 +45,7 @@ app = FastAPI(
 
 
 _detector_instance: DendroDetector | None = None
+_DEVICE_ENV_VAR = "DENDROTECTOR_DEVICE"
 
 
 def _get_detector() -> DendroDetector:
@@ -48,7 +53,8 @@ def _get_detector() -> DendroDetector:
 
     global _detector_instance
     if _detector_instance is None:
-        _detector_instance = DendroDetector()
+        requested_device = os.getenv(_DEVICE_ENV_VAR) or None
+        _detector_instance = DendroDetector(device=requested_device)
     return _detector_instance
 
 

--- a/tools/run_api_container.sh
+++ b/tools/run_api_container.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE_NAME="dendrotector-api"
+PORT=8000
+DEVICE="auto"
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") [--port PORT] [--device {cpu|cuda|cuda:N}] [--no-build]
+
+Options:
+  --port PORT       Host port to expose the API on (default: 8000).
+  --device VALUE    Execution device for the detector. Accepts "cpu", "cuda", or
+                    "cuda:N" to target a specific GPU index (default: auto).
+  --no-build        Skip rebuilding the Docker image before running.
+  -h, --help        Show this help message and exit.
+USAGE
+}
+
+SHOULD_BUILD=1
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --port)
+            PORT="$2"
+            shift 2
+            ;;
+        --device)
+            DEVICE="$2"
+            shift 2
+            ;;
+        --no-build)
+            SHOULD_BUILD=0
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if ! [[ $PORT =~ ^[0-9]+$ ]]; then
+    echo "Error: port must be a numeric value." >&2
+    exit 1
+fi
+
+GPU_ARGS=()
+DEVICE_ENV=""
+case "$DEVICE" in
+    auto)
+        DEVICE_ENV=""
+        ;;
+    cpu)
+        DEVICE_ENV="cpu"
+        ;;
+    cuda)
+        DEVICE_ENV="cuda"
+        GPU_ARGS=(--gpus all)
+        ;;
+    cuda:*)
+        GPU_INDEX="${DEVICE#cuda:}"
+        if ! [[ $GPU_INDEX =~ ^[0-9]+$ ]]; then
+            echo "Error: GPU index must be numeric (received '$GPU_INDEX')." >&2
+            exit 1
+        fi
+        DEVICE_ENV="cuda:${GPU_INDEX}"
+        GPU_ARGS=(--gpus "device=${GPU_INDEX}")
+        ;;
+    *)
+        echo "Error: unsupported device '$DEVICE'. Use cpu, cuda, or cuda:N." >&2
+        exit 1
+        ;;
+esac
+
+if [[ $SHOULD_BUILD -eq 1 ]]; then
+    docker build -t "$IMAGE_NAME" .
+fi
+
+RUN_ARGS=(docker run --rm -p "${PORT}:${PORT}" -e "PORT=${PORT}")
+
+if [[ -n $DEVICE_ENV ]]; then
+    RUN_ARGS+=( -e "DENDROTECTOR_DEVICE=${DEVICE_ENV}" )
+fi
+
+if [[ ${GPU_ARGS[*]-} ]]; then
+    RUN_ARGS+=( "${GPU_ARGS[@]}" )
+fi
+
+RUN_ARGS+=("$IMAGE_NAME")
+
+echo "Executing: ${RUN_ARGS[*]}"
+"${RUN_ARGS[@]}"


### PR DESCRIPTION
## Summary
- add a Dockerfile that builds the FastAPI service on top of the PyTorch runtime image and exposes configuration via environment variables
- allow the API to honour a DENDROTECTOR_DEVICE environment override when instantiating the detector
- provide a helper script for building and running the container with configurable port and device options

## Testing
- bash -n tools/run_api_container.sh

------
https://chatgpt.com/codex/tasks/task_e_68db9e977d74832faf3f640dbd417bf6