### PR TITLE
Document Docker cache override and add helper support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,17 @@ The first run downloads the GroundingDINO, SAM 2, and species classifier weight
 from the Hugging Face Hub into `~/.dendrocache` (or a custom directory). Ensure
 that you are authenticated with `huggingface-cli login` if the models require
 access and that you have roughly 4 GB of free disk space for the larger SAM 2
-checkpoint. Use the `--models-dir` CLI flag (or the `models_dir` constructor
-argument) to cache models elsewhere. 【F:dendrotector/detector.py†L27-L74】【F:dendrotector/species_identifier.py†L21-L46】
+checkpoint. Use the `DENDROCACHE_PATH` environment variable, the `--models-dir`
+CLI flag, or the `models_dir` constructor argument to cache models elsewhere. 【F:dendrotector/__init__.py†L1-L33】【F:dendrotector/detector.py†L27-L74】【F:dendrotector/species_identifier.py†L19-L46】
+
+If you want the Docker build/runtime to use a different location—e.g., a
+writable volume you mount from the host—set `DENDROCACHE_PATH` in the container
+environment (`docker run -e DENDROCACHE_PATH=/models …` or add another `ENV`
+line in the Dockerfile) so the resolver points the downloads at that path. You
+can mount the same directory on subsequent runs to avoid re-downloading the
+weights. The helper script at `tools/run_api_container.sh` accepts
+`--cache-dir /host/path` to bind-mount a host directory and inject
+`DENDROCACHE_PATH` automatically. 【F:tools/run_api_container.sh†L1-L126】
 
 ### Troubleshooting build issues
 

--- a/dendrotector/__init__.py
+++ b/dendrotector/__init__.py
@@ -1,0 +1,33 @@
+"""DendroDetector package utilities."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional, Union
+
+
+ENV_CACHE_PATH = "DENDROCACHE_PATH"
+_DEFAULT_CACHE_PATH = Path("~/.dendrocache")
+
+
+def resolve_cache_dir(
+    override: Optional[Union[str, Path]] = None,
+) -> Path:
+    """Resolve the directory used for storing downloaded model weights.
+
+    The directory can be customised globally by setting the
+    ``DENDROCACHE_PATH`` environment variable. Individual components may also
+    provide an explicit ``override`` path which takes precedence over the
+    environment variable.
+    """
+
+    if override is not None:
+        base = Path(override)
+    else:
+        base = Path(os.environ.get(ENV_CACHE_PATH, _DEFAULT_CACHE_PATH))
+
+    return base.expanduser().resolve()
+
+
+__all__ = ["ENV_CACHE_PATH", "resolve_cache_dir"]

--- a/dendrotector/detector.py
+++ b/dendrotector/detector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import json
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import cv2
 import torch
@@ -19,6 +19,7 @@ from sam2.sam2_image_predictor import SAM2ImagePredictor
 from sam2.build_sam import HF_MODEL_ID_TO_FILENAMES, build_sam2
 
 from species_identifier import SpeciesIdentifier
+from . import resolve_cache_dir
 
 PROMPT = "tree . shrub . bush ."
 
@@ -38,14 +39,14 @@ class DendroDetector:
         device: Optional[str] = None,
         box_threshold: float = 0.3,
         text_threshold: float = 0.25,
-        models_dir: Path = Path("~/.dendrocache"),
+        models_dir: Union[Path, str, None] = None,
     ) -> None:
-        
+
         self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
         self.box_threshold = box_threshold
         self.text_threshold = text_threshold
 
-        self._models_dir = Path(models_dir).expanduser().resolve()
+        self._models_dir = resolve_cache_dir(models_dir)
         self._models_dir.mkdir(parents=True, exist_ok=True)
 
         self._dino_model = self._load_groundingdino()

--- a/dendrotector/species_identifier.py
+++ b/dendrotector/species_identifier.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Union
 from pathlib import Path
 
 import timm
@@ -21,11 +21,13 @@ class SpeciesIdentifier:
     def __init__(
         self,
         device: str | None = None,
-        models_dir: Path = Path("~/.dendrocache")
+        models_dir: Union[Path, str, None] = None,
     ) -> None:
         self.device = device
 
-        self._models_dir = Path(models_dir).expanduser().resolve()
+        from . import resolve_cache_dir
+
+        self._models_dir = resolve_cache_dir(models_dir)
         self._models_dir.mkdir(exist_ok=True)
         
         model_dir = self._models_dir / "specifier"

--- a/tools/run_api_container.sh
+++ b/tools/run_api_container.sh
@@ -7,18 +7,22 @@ DEVICE="auto"
 
 usage() {
     cat <<USAGE
-Usage: $(basename "$0") [--port PORT] [--device {cpu|cuda|cuda:N}] [--no-build]
+Usage: $(basename "$0") [--port PORT] [--device {cpu|cuda|cuda:N}] [--cache-dir PATH] [--no-build]
 
 Options:
-  --port PORT       Host port to expose the API on (default: 8000).
-  --device VALUE    Execution device for the detector. Accepts "cpu", "cuda", or
-                    "cuda:N" to target a specific GPU index (default: auto).
-  --no-build        Skip rebuilding the Docker image before running.
-  -h, --help        Show this help message and exit.
+  --port PORT        Host port to expose the API on (default: 8000).
+  --device VALUE     Execution device for the detector. Accepts "cpu", "cuda", or
+                     "cuda:N" to target a specific GPU index (default: auto).
+  --cache-dir PATH   Host directory to persist downloaded model weights. The
+                     directory is bind-mounted into the container and exposed via
+                     the DENDROCACHE_PATH environment variable.
+  --no-build         Skip rebuilding the Docker image before running.
+  -h, --help         Show this help message and exit.
 USAGE
 }
 
 SHOULD_BUILD=1
+CACHE_DIR=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -28,6 +32,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --device)
             DEVICE="$2"
+            shift 2
+            ;;
+        --cache-dir)
+            CACHE_DIR="$2"
             shift 2
             ;;
         --no-build)
@@ -49,6 +57,16 @@ done
 if ! [[ $PORT =~ ^[0-9]+$ ]]; then
     echo "Error: port must be a numeric value." >&2
     exit 1
+fi
+
+if [[ -n $CACHE_DIR ]]; then
+    if [[ ! -d $CACHE_DIR ]]; then
+        mkdir -p -- "$CACHE_DIR"
+    fi
+
+    pushd "$CACHE_DIR" >/dev/null
+    CACHE_DIR_ABS=$(pwd)
+    popd >/dev/null
 fi
 
 GPU_ARGS=()
@@ -87,6 +105,10 @@ RUN_ARGS=(docker run --rm -p "${PORT}:${PORT}" -e "PORT=${PORT}")
 
 if [[ -n $DEVICE_ENV ]]; then
     RUN_ARGS+=( -e "DENDROTECTOR_DEVICE=${DEVICE_ENV}" )
+fi
+
+if [[ -n ${CACHE_DIR_ABS-} ]]; then
+    RUN_ARGS+=( -e "DENDROCACHE_PATH=${CACHE_DIR_ABS}" -v "${CACHE_DIR_ABS}:${CACHE_DIR_ABS}")
 fi
 
 if [[ ${GPU_ARGS[*]-} ]]; then


### PR DESCRIPTION
## Summary
- document how to point Docker builds and runs at a custom DENDROCACHE_PATH and reference the helper script
- add a --cache-dir flag to tools/run_api_container.sh to mount a persistent cache and propagate DENDROCACHE_PATH

## Testing
- python -m compileall dendrotector

------
https://chatgpt.com/codex/tasks/task_e_68dbf49b1608832faf44c8cd702a5723