### PR TITLE
Use volume-backed cache for model weights and document Docker usage

### DIFF
--- a/dendrotector/__init__.py
+++ b/dendrotector/__init__.py
@@ -1,4 +1,10 @@
-"""DendroDetector package utilities."""
+"""DendroDetector package utilities.
+
+This module centralises cache-path handling so that all heavyweight model
+artifacts are stored in a user-controlled directory (typically a bind-mounted
+volume when running inside Docker). The helpers make the Hugging Face Hub reuse
+the same directory, preventing duplicate downloads in ephemeral containers.
+"""
 
 from __future__ import annotations
 
@@ -9,6 +15,23 @@ from typing import Optional, Union
 
 ENV_CACHE_PATH = "DENDROCACHE_PATH"
 _DEFAULT_CACHE_PATH = Path("~/.dendrocache")
+
+_ENV_HF_HOME = "HF_HOME"
+_ENV_HF_CACHE = "HUGGINGFACE_HUB_CACHE"
+_HF_SUBDIR = "huggingface"
+
+
+def _ensure_hf_environment(base: Path) -> None:
+    """Ensure Hugging Face caches live inside the shared models directory."""
+
+    hf_cache = base / _HF_SUBDIR
+    hf_cache.mkdir(parents=True, exist_ok=True)
+
+    if _ENV_HF_HOME not in os.environ:
+        os.environ[_ENV_HF_HOME] = str(hf_cache)
+
+    if _ENV_HF_CACHE not in os.environ:
+        os.environ[_ENV_HF_CACHE] = str(hf_cache)
 
 
 def resolve_cache_dir(
@@ -27,7 +50,16 @@ def resolve_cache_dir(
     else:
         base = Path(os.environ.get(ENV_CACHE_PATH, _DEFAULT_CACHE_PATH))
 
-    return base.expanduser().resolve()
+    resolved = base.expanduser().resolve()
+    _ensure_hf_environment(resolved)
+    return resolved
 
 
-__all__ = ["ENV_CACHE_PATH", "resolve_cache_dir"]
+def resolve_hf_cache_dir(override: Optional[Union[str, Path]] = None) -> Path:
+    """Return the directory used by the Hugging Face Hub cache."""
+
+    base = resolve_cache_dir(override)
+    return (base / _HF_SUBDIR).expanduser().resolve()
+
+
+__all__ = ["ENV_CACHE_PATH", "resolve_cache_dir", "resolve_hf_cache_dir"]

--- a/dendrotector/species_identifier.py
+++ b/dendrotector/species_identifier.py
@@ -25,16 +25,24 @@ class SpeciesIdentifier:
     ) -> None:
         self.device = device
 
-        from . import resolve_cache_dir
+        from . import resolve_cache_dir, resolve_hf_cache_dir
 
         self._models_dir = resolve_cache_dir(models_dir)
         self._models_dir.mkdir(exist_ok=True)
-        
-        model_dir = self._models_dir / "specifier"
+
+        model_dir = resolve_hf_cache_dir(self._models_dir) / "specifier"
         model_dir.mkdir(parents=True, exist_ok=True)
 
-        labels_path = hf_hub_download(MODEL_REPO, filename="labels.json", local_dir=model_dir)
-        ckpt_path = hf_hub_download(MODEL_REPO, filename="pytorch_model.bin", local_dir=model_dir)
+        labels_path = hf_hub_download(
+            MODEL_REPO,
+            filename="labels.json",
+            cache_dir=str(model_dir),
+        )
+        ckpt_path = hf_hub_download(
+            MODEL_REPO,
+            filename="pytorch_model.bin",
+            cache_dir=str(model_dir),
+        )
 
         with open(labels_path, "r", encoding="utf-8") as f:
             raw = json.load(f)


### PR DESCRIPTION
## Summary
- ensure the cache resolver configures Hugging Face to reuse the shared models directory
- download detector and classifier weights via cache_dir paths that live on the mounted volume
- rewrite the Docker helper script and README to document env-based configuration and how to submit detection jobs

## Testing
- python -m compileall dendrotector

------
https://chatgpt.com/codex/tasks/task_e_68dbfb1b0ec8832faa59c12c3d3023aa