### PR TITLE
Improve cache reuse and documentation structure

### DIFF
--- a/APP.md
+++ b/APP.md
@@ -1,0 +1,74 @@
+# Dendrotector service deployment
+
+This guide covers running the packaged FastAPI service with Docker. The
+repository bundles a helper script that builds the image, forwards the required
+ports, and binds the shared model cache so that large checkpoints persist across
+container restarts.【F:tools/run_api_container.sh†L1-L109】
+
+## Launching the container
+
+Use `tools/run_api_container.sh` to build the image and start the API server. The
+wrapper exposes three environment variables:
+
+- `PORT` – host port forwarded to the container (defaults to `58000`).
+- `DEVICE` – `auto`, `cpu`, `cuda`, or `cuda:N` to pin a specific GPU.
+- `DENDROCACHE_PATH` – optional override for the shared model cache.
+
+```bash
+export PORT=8080
+export DEVICE=cuda:0
+export DENDROCACHE_PATH=~/dendrocache  # optional; defaults to ~/.dendrocache
+./tools/run_api_container.sh
+```
+
+When `DENDROCACHE_PATH` is unset the script mounts the host’s `~/.dendrocache`
+into `/root/.dendrocache` inside the container. If you do set
+`DENDROCACHE_PATH`, its absolute path is reused both on the host and inside the
+container so that the directory is always a Docker volume. In either case the
+script exports `HF_HOME` and `HUGGINGFACE_HUB_CACHE` to the same bind mount,
+ensuring that the Hugging Face Hub never duplicates checkpoints.【F:tools/run_api_container.sh†L1-L109】
+
+The resulting container binds uvicorn to `0.0.0.0:${PORT}`, meaning requests sent
+to `http://<host>:${PORT}` reach the FastAPI application directly without extra
+port forwarding.【F:Dockerfile†L16-L20】【F:dendrotector/api.py†L8-L116】
+
+## Hugging Face authentication
+
+Private Hugging Face repositories require a token. Export it before running the
+helper script and the API will log in automatically during the first model
+initialisation. The wrapper forwards `DENDROTECTOR_HF_TOKEN`, `HF_TOKEN`, and
+`HUGGING_FACE_HUB_TOKEN` into the container without echoing secrets.
+
+```bash
+export DENDROTECTOR_HF_TOKEN="hf_..."
+./tools/run_api_container.sh
+```
+
+Interactive authentication via `huggingface-cli login` remains available inside
+the running container if you prefer that approach.【F:dendrotector/__init__.py†L47-L122】
+
+## Submitting detection requests
+
+After the container is up you can submit a detection job with a simple `curl`
+command. The response is a ZIP archive containing per-instance artefacts
+alongside a `summary.json` file with the total instance count.【F:dendrotector/api.py†L58-L116】
+
+```bash
+curl -X POST "http://localhost:${PORT}/detect?top_k=3" \
+  -F "image=@/path/to/trees.jpg" \
+  --output detections.zip
+```
+
+## Troubleshooting image builds
+
+The public PyPI wheel (`groundingdino-py`) omits CUDA sources, leading to build
+failures such as
+`cc1plus: fatal error: .../groundingdino/models/GroundingDINO/csrc/vision.cpp: No such file or directory`.
+This project pins the official Git repository instead, which includes the needed
+sources. When building on Debian or Ubuntu, install the system dependencies
+before running `pip install` inside the container:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential ninja-build
+```

--- a/dendrotector/detector.py
+++ b/dendrotector/detector.py
@@ -13,13 +13,11 @@ from PIL import Image
 from groundingdino.util import box_ops
 from groundingdino.util.inference import load_image, load_model, predict
 
-from huggingface_hub import hf_hub_download
-
 from sam2.sam2_image_predictor import SAM2ImagePredictor
 from sam2.build_sam import HF_MODEL_ID_TO_FILENAMES, build_sam2
 
 from .species_identifier import SpeciesIdentifier
-from . import resolve_cache_dir, resolve_hf_cache_dir
+from . import ensure_local_hf_file, resolve_cache_dir, resolve_hf_cache_dir
 
 PROMPT = "tree . shrub . bush ."
 
@@ -62,15 +60,15 @@ class DendroDetector:
         groundingdino_dir = self._hf_cache_dir / "groundingdino"
         groundingdino_dir.mkdir(parents=True, exist_ok=True)
 
-        config_path = hf_hub_download(
+        config_path = ensure_local_hf_file(
             GROUNDING_REPO,
             GROUNDING_CONFIG,
-            cache_dir=str(groundingdino_dir),
+            groundingdino_dir,
         )
-        weights_path = hf_hub_download(
+        weights_path = ensure_local_hf_file(
             GROUNDING_REPO,
             GROUNDING_WEIGHTS,
-            cache_dir=str(groundingdino_dir),
+            groundingdino_dir,
         )
 
         model = load_model(str(config_path), str(weights_path))
@@ -85,10 +83,10 @@ class DendroDetector:
         sam2_dir.mkdir(parents=True, exist_ok=True)
 
         config_name, checkpoint_name = HF_MODEL_ID_TO_FILENAMES[SAM2_REPO]
-        ckpt_path   = hf_hub_download(
+        ckpt_path = ensure_local_hf_file(
             SAM2_REPO,
-            filename=checkpoint_name,
-            cache_dir=str(sam2_dir),
+            checkpoint_name,
+            sam2_dir,
         )
 
         sam_model_instance = build_sam2(

--- a/dendrotector/species_identifier.py
+++ b/dendrotector/species_identifier.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import timm
 import torch
 from PIL import Image
-from huggingface_hub import hf_hub_download
 from timm.data.transforms_factory import create_transform
 from timm.data.constants import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD
 
@@ -25,7 +24,7 @@ class SpeciesIdentifier:
     ) -> None:
         self.device = device
 
-        from . import resolve_cache_dir, resolve_hf_cache_dir
+        from . import ensure_local_hf_file, resolve_cache_dir, resolve_hf_cache_dir
 
         self._models_dir = resolve_cache_dir(models_dir)
         self._models_dir.mkdir(exist_ok=True)
@@ -33,15 +32,15 @@ class SpeciesIdentifier:
         model_dir = resolve_hf_cache_dir(self._models_dir) / "specifier"
         model_dir.mkdir(parents=True, exist_ok=True)
 
-        labels_path = hf_hub_download(
+        labels_path = ensure_local_hf_file(
             MODEL_REPO,
-            filename="labels.json",
-            cache_dir=str(model_dir),
+            "labels.json",
+            model_dir,
         )
-        ckpt_path = hf_hub_download(
+        ckpt_path = ensure_local_hf_file(
             MODEL_REPO,
-            filename="pytorch_model.bin",
-            cache_dir=str(model_dir),
+            "pytorch_model.bin",
+            model_dir,
         )
 
         with open(labels_path, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- add a helper that reuses local Hugging Face weights before downloading and apply it to the detector and species classifier
- refresh the README to describe the cache behaviour and point to a new deployment guide
- introduce `APP.md` with Docker/FastAPI instructions that were moved out of the main README

## Testing
- python -m compileall dendrotector

------
https://chatgpt.com/codex/tasks/task_e_68dceacec0f4832f96af1691c196a148